### PR TITLE
[WIP]商品購入機能実装

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -23,3 +23,4 @@
 @import "modules/users/header";
 @import "modules/users/footer";
 @import "layouts/error_messages";
+@import "layouts/flash_messages";

--- a/app/assets/stylesheets/layouts/flash_messages.scss
+++ b/app/assets/stylesheets/layouts/flash_messages.scss
@@ -1,0 +1,12 @@
+.notifications {
+  color: $white;
+  text-align: center;  
+
+  .notice {
+    background-color: lightBlue;
+  }
+
+  .alert {
+    background-color: alert_orange;
+  }
+}

--- a/app/controllers/credit_cards_controller.rb
+++ b/app/controllers/credit_cards_controller.rb
@@ -1,5 +1,6 @@
 class CreditCardsController < ApplicationController
   require "payjp"
+  before_action :set_item, only: [:new]
   before_action :set_card
 
   def index #CardのデータをPayjpに送って情報を取り出す
@@ -31,7 +32,7 @@ class CreditCardsController < ApplicationController
 
   def new     # カードの登録画面。送信ボタンを押すとcreateアクションへ。
     @card = CreditCard.where(user_id: current_user.id).first
-    redirect_to "/purchases/pay" if @card.present?
+    redirect_to pay_purchase_path(@item.id) if @card.present?
   end
 
    def create     # PayjpとCardのデータベースを作成
@@ -65,6 +66,12 @@ class CreditCardsController < ApplicationController
   end
 
   private
+
+  def set_item
+    @item = Item.find(params[:id])
+    @images = @item.product_images
+    @image = @images.first 
+  end
 
   def set_card
     @card = CreditCard.where(user_id: current_user.id).first if CreditCard.where(user_id: current_user.id).present?

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -27,7 +27,7 @@ class ItemsController < ApplicationController
   
   def show
     @item = Item.find(params[:id])
-    @images = @item.product_image
+    @images = @item.product_images
     @image = @images.first 
   end
 
@@ -58,7 +58,7 @@ class ItemsController < ApplicationController
       product_images_attributes: [:id, 
                                  :image,
                                  :item_id],)
-      # .merge(seller_id: current_user.id)
+      .merge(seller_id: current_user.id)
   end
 
 end

--- a/app/controllers/purchases_controller.rb
+++ b/app/controllers/purchases_controller.rb
@@ -1,23 +1,21 @@
 class PurchasesController < ApplicationController
   require "payjp"
+  before_action :set_item, only: [:show, :verification_address, :create, :purchases_verification, :pay, :buy]
   before_action :set_card
   
   def show
-    # @item = Item.find(params[:id])
-    # @images = @item.product_image
-    # @image = @images.first 
   end
   
   def verification_address
-    @address = Address.new 
+    @address = Address.new
   end
   
   def create
     @address = Address.new(address_params)
     if @address.save
-      redirect_to purchases_verification_purchases_path(@address)
+      redirect_to  purchases_verification_purchase_path(@item.id)
     else
-      render 'verification_address'
+      render "verification_address"
     end
   end
   
@@ -28,28 +26,27 @@ class PurchasesController < ApplicationController
   end
 
   def buy
-    @item = Item.find(params[:id])
     # すでに購入されていないか？
     if @item.buyer.present? 
       redirect_to root_path
     elsif @card.blank?
-      # カード情報がなければ、買えないから戻す
-      redirect_to action: "new"
+      # カード情報がなければ、買えないから戻します。
+      redirect_to "new_credit_card"
       flash[:alert] = '購入にはクレジットカード登録が必要です'
     else
-      # 購入者もいないし、クレジットカードもあるし、決済処理に移行
+      # 購入者もいないし、クレジットカードもあるし、決済処理に移行します。
       Payjp.api_key = ENV["PAYJP_PRIVATE_KEY"]
       # 請求を発行
       Payjp::Charge.create(
-      # amount: @item.price,
-      amount: 1000,
+      amount: @item.price,
       customer: @card.customer_id,
       currency: 'jpy',
       )
       # 売り切れなので、itemの情報をアップデートして売り切れにします。
       if @item.update(product_status: 2, buyer_id: current_user.id)
         flash[:notice] = '購入しました。'
-        redirect_to controller: 'purchases', action: 'show', id: @item.id
+        redirect_to root_path
+        # redirect_to controller: 'purchases', action: 'show', id: @item.id
       else
         flash[:alert] = '購入に失敗しました。'
         redirect_to controller: 'purchases' , action: 'show', id: @item.id
@@ -58,11 +55,18 @@ class PurchasesController < ApplicationController
     end
 
   private
-    def set_card
-      @card = CreditCard.where(user_id: current_user.id).first if CreditCard.where(user_id: current_user.id).present?
-    end
+
+  def set_item
+    @item = Item.find(params[:id])
+    @images = @item.product_images
+    @image = @images.first 
+  end
+
+  def set_card
+    @card = CreditCard.where(user_id: current_user.id).first if CreditCard.where(user_id: current_user.id).present?
+  end
     
-    def address_params
-      params.require(:address).permit(:firstname, :familyname, :firstname_kana, :familyname_kana, :postal_code, :prefectures, :municipality, :address, :building_name).merge(user_id: current_user.id)
-    end
+  def address_params
+    params.require(:address).permit(:firstname, :familyname, :firstname_kana, :familyname_kana, :postal_code, :prefectures, :municipality, :address, :building_name).merge(user_id: current_user.id)
+  end
 end

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -8,8 +8,8 @@ class Address < ApplicationRecord
               with: /\A\d{3}[-]\d{4}$|^\d{3}[-]\d{2}$|^\d{3}\z/
             }
   validates :firstname_kana, :familyname_kana,
-            format: {
-              with: /\A[\p{katakana} ー－&&[^ -~｡-ﾟ]]+\z/,
-              message: "全角カタカナのみで入力して下さい"
-            }
+              format: {
+                with: /\A[\p{katakana} ー－&&[^ -~｡-ﾟ]]+\z/,
+                  message: "全角カタカナのみで入力して下さい"
+              }
 end

--- a/app/models/credit_card.rb
+++ b/app/models/credit_card.rb
@@ -1,3 +1,19 @@
 class CreditCard < ApplicationRecord
   belongs_to :user
+
+  #バリデーション
+  # これから実装していきます
+  # VALID_NUMBER_REGEX = /\A\d{14,16}\z/
+  # VALID_YAER_REGEX = /\A\d{2}\z/
+  # VALID_MONTH_REGEX = /\A\d{2}\z/
+  # VALID_CVC_REGEX = /\A\d{3,4}\z/
+  
+  # validates :number, presence: true,
+  #             format: { with: VALID_NUMBER_REGEX }
+  # validates :exp_month, presence: true,
+  #             format: { with: VALID_YAER_REGEX }
+  # validates :exp_year, presence: true,
+  #             format: { with: VALID_MONTH_REGEX }
+  # validates :cvc, presence: true, length: { is: 3 },
+  #             format: { with: VALID_CVC_REGEX }
 end

--- a/app/views/items/shared/_item-buy-button.html.haml
+++ b/app/views/items/shared/_item-buy-button.html.haml
@@ -3,4 +3,4 @@
     = link_to "購入画面に進む", new_user_session_path
 -else user_signed_in? || @item.seller_id != current_user.id
   .item-box__buy-button
-    = link_to "購入画面に進む", purchase_path
+    = link_to "購入画面に進む", purchase_path(@item.id)

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -36,7 +36,7 @@
               %li 
                 = image_tag @image.image, size: "560x346", class: "item-main-photo" 
                 %ul
-                  - @item.product_image.each.with_index do |image, index|
+                  - @item.product_images.each.with_index do |image, index|
                     %li
                       = image_tag(image.image, size: "140x87", class: "item-change-photo" )
           .item-box__price

--- a/app/views/layouts/_flash_messages.html.haml
+++ b/app/views/layouts/_flash_messages.html.haml
@@ -1,0 +1,3 @@
+.notifications
+  - flash.each do |key, value|
+    = content_tag(:div, value, class: key)

--- a/app/views/purchases/pay.html.haml
+++ b/app/views/purchases/pay.html.haml
@@ -1,4 +1,3 @@
--# 購入機能用です(今後実装予定です)
 .verification-wrapper
   .verification_header
     = render partial: 'items/shared/verification_header'
@@ -10,16 +9,13 @@
         .verification-content__item__body__caption
           .verification-content__item__body__caption--center
             .verification-content__item__image
-              = image_tag("sozai-09.png")
-              -# = image_tag(@image.image, size: "80x80")
+              = image_tag(@image.image, size: "80x80")
             .verification-content__item__detail
               %p.verification-content__item__detail__name
-                星
-                -# = @item.product_name
+                = @item.product_name
               %p.verification-content__item__detail__price
                 %span
-                  ￥1,000
-                  -# = number_to_currency(@item.price, unit: "￥", precision: 0)
+                  = number_to_currency(@item.price, unit: "￥", precision: 0)
                 %span
                   (税込) 送料込み
       %section.verification-content__item--payment
@@ -31,8 +27,7 @@
                   支払い金額
                 .verification-form__content__list__price
                   %span
-                    ￥1,000
-                    -# = number_to_currency(@item.price, unit: "￥", precision: 0)
+                    = number_to_currency(@item.price, unit: "￥", precision: 0)
             %section.verification-form__button
               = form_tag(buy_purchase_path, method: :post) do
                 %button 購入する

--- a/app/views/purchases/purchases_verification.html.haml
+++ b/app/views/purchases/purchases_verification.html.haml
@@ -9,16 +9,13 @@
         .verification-content__item__body__caption
           .verification-content__item__body__caption--center
             .verification-content__item__image
-              = image_tag("sozai-09.png")
-              -# = image_tag(@image.image, size: "80x80")
+              = image_tag(@image.image, size: "80x80")
             .verification-content__item__detail
               %p.verification-content__item__detail__name
-                星
-                -# = @item.product_name
+                = @item.product_name
               %p.verification-content__item__detail__price
                 %span
-                  ¥1,000
-                  -# = number_to_currency(@item.price, unit: "￥", precision: 0)     # number_to_currencyはメソッド名です。unitは通貨単位を指定してます。(デフォルトは$です) precisionは少数以下の桁の指定です。(今回は小数点以下は切り捨てたいので0です)
+                  = number_to_currency(@item.price, unit: "￥", precision: 0)     # number_to_currencyはメソッド名です。unitは通貨単位を指定してます。(デフォルトは$です) precisionは少数以下の桁の指定です。(今回は小数点以下は切り捨てたいので0です)
                 %span
                   (税込) 送料込み
       %section.verification-content__item--payment
@@ -30,13 +27,12 @@
                   支払い金額
                 .verification-form__content__list__price
                   %span
-                    ¥1,000
-                    -# = number_to_currency(@item.price, unit: "￥", precision: 0)
+                    = number_to_currency(@item.price, unit: "￥", precision: 0)
             %section.verification-form--payment
               .verification-form--payment__body
                 %h3
                   支払い方法
-                = link_to new_credit_card_path(current_user.id) do
+                = link_to credit_card_path(@item) do
                   %i.fas.fa-plus-circle
                   %span
                     登録してください

--- a/app/views/purchases/show.html.haml
+++ b/app/views/purchases/show.html.haml
@@ -37,14 +37,6 @@
                   %i.fas.fa-plus-circle
                   %span
                     登録してください
-            -# %section.verification-form--payment
-            -#   .verification-form--payment__body
-            -#     %h3
-            -#       支払い方法
-            -#     = link_to credit_card_path(@item) do
-            -#       %i.fas.fa-plus-circle
-            -#       %span
-            -#         登録してください
             %section.verification-form__button
               = form_tag(buy_purchase_path, method: :post) do
                 %button 購入する

--- a/app/views/purchases/show.html.haml
+++ b/app/views/purchases/show.html.haml
@@ -1,4 +1,5 @@
 .verification-wrapper
+  = render "layouts/flash_messages"
   .verification_header
     = render partial: 'items/shared/verification_header'
   .verification-content
@@ -9,36 +10,43 @@
         .verification-content__item__body__caption
           .verification-content__item__body__caption--center
             .verification-content__item__image
-              = image_tag("sozai-09.png")
-              -# = image_tag(@image.image, size :80x80)
+              = image_tag(@image.image, size: "80x80")
             .verification-content__item__detail
               %p.verification-content__item__detail__name
-                星
-                -# = @item.product_name
+                = @item.product_name
               %p.verification-content__item__detail__price
                 %span
-                  ￥1,000
-                  -# = number_to_currency(@item.price, unit: "￥", precision: 0)
+                  = number_to_currency(@item.price, unit: "￥", precision: 0)
                 %span
                   (税込) 送料込み
       %section.verification-content__item--payment
         .verification-content__item--payment-body
-          %form.verification-form
+          .verification-form
             %ul.verification-form__content
               %li.verification-form__content__list
                 .verification-form__content__list__title
                   支払い金額
                 .verification-form__content__list__price
                   %span
-                    ￥1,000
-                    -# = number_to_currency(@item.price, unit: "￥", precision: 0)
+                    = number_to_currency(@item.price, unit: "￥", precision: 0)
             %section.verification-form__address
               .verification-form__address__body
                 %h3
                   配送先
-                = link_to verification_address_purchases_path do
+                = link_to verification_address_purchase_path do
                   %i.fas.fa-plus-circle
                   %span
                     登録してください
+            -# %section.verification-form--payment
+            -#   .verification-form--payment__body
+            -#     %h3
+            -#       支払い方法
+            -#     = link_to credit_card_path(@item) do
+            -#       %i.fas.fa-plus-circle
+            -#       %span
+            -#         登録してください
+            %section.verification-form__button
+              = form_tag(buy_purchase_path, method: :post) do
+                %button 購入する
   .verification_footer
     = render partial: 'items/shared/verification_footer'

--- a/app/views/purchases/verification_address.html.haml
+++ b/app/views/purchases/verification_address.html.haml
@@ -5,7 +5,7 @@
     .verification-address-content__item
       %h2.verification-address-content__item__title
         発送元・お届け先住所入力
-  = form_for @address, url: purchases_path do |f|
+  = form_for @address, url: purchase_path do |f|
     - if @address.errors.any?
       = render 'layouts/error_messages', model: f.object
     .verification-address-content__product

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,19 +17,24 @@ Rails.application.routes.draw do
       get :sms_input
       get :completed
     end
+    member do
+      get "/credit_cards/:id/new" => "credit_card#new"
+    end
   end
   
-  resources :purchases, only: [:show, :create] do
-    collection do
-      get :verification_address
-      get :purchases_verification
-    end
+  resources :purchases, only: [:show] do
     member do
+      get :verification_address
+      post :create
+      get "purchases_verification", to: "purchases#purchases_verification"
       get "pay", to: "purchases#pay"
       post "buy", to: "purchases#buy"
     end
   end
-  resources :credit_cards, only: [:index, :new, :create] do
+  resources :credit_cards, only: [:index, :create] do
+    member do
+      get "new"
+    end
     collection do
       post "delete", to: "credit_cards#delete"
     end

--- a/spec/factories/address.rb
+++ b/spec/factories/address.rb
@@ -1,0 +1,14 @@
+# FactoryBot.define do
+
+#   factory :address do
+#     familyname     {"山田"}
+#     firstname     {"彩"}
+#     familyname_kana     {"ヤマダ"}
+#     firstname_kana     {"アヤ"}
+#     postal_code     {"123-4567"}
+#     prefectures     {"北海道"}
+#     municipality     {"横浜市緑区"}
+#     address     {"青山1-1-1"}
+#   end
+
+# end

--- a/spec/models/address_spac.rb
+++ b/spec/models/address_spac.rb
@@ -1,0 +1,70 @@
+# require 'rails_helper'
+# describe Address do
+#   describe '#create' do
+#     it "firstnameがない場合は登録できないこと" do
+#       address = build(:address, firstname: "")
+#       address.valid?
+#       expect(address.errors[:firstname]).to include("can't be blank")
+#     end
+
+#     it "familynameがない場合は登録できないこと"do
+#       address = build(:address, familyname: "")
+#       address.valid?
+#       expect(address.errors[:familyname]).to include("can't be blank")
+#     end
+
+#     it "firstname_kanaがない場合は登録できないこと" do
+#       address = build(:address, firstname_kana: "")
+#       address.valid?
+#       expect(address.errors[:firstname_kana]).to include("can't be blank")
+#     end
+
+#     it "firstname_kanaにカタカナ以外がある場合は登録できないこと " do
+#       address = build(:user, firstname_kana: "カナa")
+#       address.valid?
+#       expect(address.errors[:firstname_kana][0]).to include("is invalid")
+#     end
+
+#     it "familyname_kanaがない場合は登録できないこと" do
+#       address = build(:address, familyname_kana: "")
+#       address.valid?
+#       expect(address.errors[:familyname_kana]).to include("can't be blank")
+#     end
+
+#     it "familyname_kanaにカタカナ以外がある場合は登録できないこと " do
+#       address = build(:address, familyname_kana: "カナa")
+#       address.valid?
+#       expect(address.errors[:familyname_kana][0]).to include("is invalid")
+#     end
+
+#     it "postal_codeがない場合は登録できないこと" do
+#       address = build(:address, postal_code: "")
+#       address.valid?
+#       expect(address.errors[:postal_code]).to include("can't be blank")
+#     end
+
+#     it "postal_codeにハイフンがあり7桁であれば登録できること" do
+#       address = build(:address, postal_code: "1234567")
+#       address.valid?
+#       expect(address.errors[:postal_code]).to include()
+#     end
+
+#     it "prefecturesがない場合は登録できないこと" do
+#       address = build(:address, prefectures: "")
+#       address.valid?
+#       expect(address.errors[:prefectures]).to include("can't be blank")
+#     end
+
+#     it "municipalityがない場合は登録できないこと" do
+#       address = build(:address, municipality: "")
+#       address.valid?
+#       expect(address.errors[:municipality]).to include("can't be blank")
+#     end
+
+#     it "addressがない場合は登録できないこと" do
+#       address = build(:address, address: "")
+#       address.valid?
+#       expect(address.errors[:address]).to include("can't be blank")
+#     end
+#   end
+# end


### PR DESCRIPTION
# what
登録したクレジットカードで商品を購入するためです。

# why
出品された商品を購入するためには必要な機能です。

購入前の商品情報です。
https://gyazo.com/296995af73454702982c6457283f2d77

商品詳細ページ → 商品購入確認ページ1 → 住所登録ページです。
https://gyazo.com/a16a9806a908b09c809b1044b77d4169

住所登録ページ → 商品購入確認ページ2 → クレジットカード登録ページ(カードは登録済みなので、このページは飛ばされて商品購入確認ページ3に遷移してます)です。
https://gyazo.com/02bd7ae37451a1d4da60bf1a21c20acf

商品購入確認ページ3 → トップページです。
https://gyazo.com/32fa77637caa6aed4ca3a0af4c96d20b

購入したら、product_statusが2buyer_idが3(user_id)になります。
https://gyazo.com/083e1db56070ab84bdd40b22fbc95109

pay.jpです。
https://gyazo.com/0259a9f53e92d8753d31b50c3db2f77b