### PR TITLE
商品出品ページとカテゴリー機能　微修正済み

### DIFF
--- a/app/assets/javascripts/new_item.js
+++ b/app/assets/javascripts/new_item.js
@@ -286,41 +286,48 @@ $(function(){
 
   // 親カテゴリーが選択されたとき発火
   $("#parent-category").on("change", function(){
+    // 小カテゴリーと孫カテゴリー削除
+    $('#children_wrapper').remove();
+    $('#grandchildren_wrapper').remove();
     // 親IDのname属性削除
     $('#parent-category').removeAttr('name');
-    $.ajax({
-      url: "/items/get_category_children",
-      type: "GET",
-      data: { parent_category_id: parent_category_id },
-      dataType: 'json',
-      contentType: false
-    })
-    .done(function(children){
-      $('#children_wrapper').remove();
-      var insertHTML = "";
-      children.forEach(function(child){
-        insertHTML += appendOption(child);
+    var parent_category_id = $('#parent-category').val();
+    if (parent_category_id.length > 1){
+      $.ajax({
+        url: "/items/get_category_children",
+        type: "GET",
+        data: { parent_category_id: parent_category_id },
+        dataType: 'json',
+        contentType: false
       })
-      appendChildrenBox(insertHTML);
-    })
+      .done(function(children){
+        var insertHTML = "";
+        children.forEach(function(child){
+          insertHTML += appendOption(child);
+        })
+        appendChildrenBox(insertHTML);
+      })
+    }
   })
   // 小カテゴリーが選択されたとき発火
   $(document).on("change", "#child-category", function(){
+    $('#grandchildren_wrapper').remove();
     var child_category_id = $("#child-category").val();
-    $.ajax({
-      url: "/items/get_category_grandchildren",
-      type: "GET",
-      data: { child_category_id: child_category_id },
-      dataType: 'json',
-      contentType: false
-    })
-    .done(function(grandchildren){
-      $('#grandchildren_wrapper').remove();
-      var insertHTML = "";
-      grandchildren.forEach(function(grandchild){
-        insertHTML += appendOption(grandchild);
+    if (child_category_id.length > 1){
+      $.ajax({
+        url: "/items/get_category_grandchildren",
+        type: "GET",
+        data: { child_category_id: child_category_id },
+        dataType: 'json',
+        contentType: false
       })
-      appendGrandchildrenBox(insertHTML)
-    })
+      .done(function(grandchildren){
+        var insertHTML = "";
+        grandchildren.forEach(function(grandchild){
+          insertHTML += appendOption(grandchild);
+        })
+        appendGrandchildrenBox(insertHTML)
+      })
+    }
   })
 })

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,4 +1,7 @@
 class ItemsController < ApplicationController
+  # ログイン中のユーザーのみ実行可能にする（トップページと商品詳細ページは除く）
+  before_action :authenticate_user!, {only: [:new, :create, :edit, :destroy]}
+
   def index
     @items = Item.limit(3).order('created_at DESC')
   end


### PR DESCRIPTION
# WHAT
ログインユーザーのみしか商品出品及び商品削除、商品編集できなくしました。

ログイン前
[![Screenshot from Gyazo](https://gyazo.com/e822276892f76a848ceedfe4db104a8b/raw)](https://gyazo.com/e822276892f76a848ceedfe4db104a8b)

ログイン後
[![Screenshot from Gyazo](https://gyazo.com/d0f0f8437f33c481924a37b1adf746f4/raw)](https://gyazo.com/d0f0f8437f33c481924a37b1adf746f4)

また、カテゴリー機能に微修正を加えて、ユーザーが意地悪的に選択しても正常に選択できるようにしました。
また、出品時にitemsテーブルのseller_idカラムにログインユーザーのidを加えて、商品から出品者を追えるようにしました。

# WHY
フリマアプリに必要な動作なため
