### PR TITLE
商品詳細表示の実装修正（カテゴリー表示）

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -54,6 +54,9 @@ class ItemsController < ApplicationController
     @condition = @item.product_condition
     @days_of_ship = @item.days_of_ship
     @charge = @item.shipping_charge
+    @grandchildren = Category.find(@item.category_id)
+    @children = @grandchildren.parent
+    @parent = @children.parent
   end
 
   def edit

--- a/app/views/items/shared/_item-buy-button.html.haml
+++ b/app/views/items/shared/_item-buy-button.html.haml
@@ -4,3 +4,6 @@
 -if user_signed_in? && @item.seller_id != current_user.id
   .item-box__buy-button
     = link_to "購入画面に進む", purchase_path(@item.id)
+-if @item.buyer_id.present?
+  .item-box__buy-button
+    = link_to "売り切れました", ""

--- a/app/views/items/shared/_item-buy-button.html.haml
+++ b/app/views/items/shared/_item-buy-button.html.haml
@@ -1,9 +1,9 @@
--if not user_signed_in?
-  .item-box__buy-button
-    = link_to "購入画面に進む", new_user_session_path
--if user_signed_in? && @item.seller_id != current_user.id
-  .item-box__buy-button
-    = link_to "購入画面に進む", purchase_path(@item.id)
--if @item.buyer_id.present?
+-if @item.product_status == 2
   .item-box__buy-button
     = link_to "売り切れました", ""
+-elsif not user_signed_in? 
+  .item-box__buy-button
+    = link_to "購入画面に進む", new_user_session_path
+-elsif user_signed_in? && @item.seller_id != current_user.id
+  .item-box__buy-button
+    = link_to "購入画面に進む", purchase_path(@item.id)

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -8,22 +8,19 @@
     %li
       %i.fa.fa-angle-right
     %li
-      = link_to  "＃" do
-        レディース
+      = link_to  @parent.name, "" 
     %li
       %i.fa.fa-angle-right
     %li
-      = link_to "＃" do
-        トップス
+      = link_to @children.name, "" 
     %li
       %i.fa.fa-angle-right
     %li
-      = link_to "＃" do
-        Tシャツ/カットソー(半袖/袖なし)
+      = link_to @grandchildren.name, ""
     %li
       %i.fa.fa-angle-right
     %li
-      %p product1
+      %p #{@item.product_name}
 
 .item-detail
   .item-detail__main
@@ -60,6 +57,11 @@
                 %tr
                   %th カテゴリー
                   %td 
+                    = link_to  @parent.name, "#"
+                    %br
+                    = link_to  @children.name, "#"
+                    %br
+                    = link_to  @grandchildren.name, "#"
                 %tr.item-brand
                   %th ブランド
                   %td 

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -143,5 +143,5 @@
             %i.fa.fa-angle-right
       .related-items
         = link_to  "＃" do
-          レディースをもっと見る
+          #{@parent.name}をもっと見る
   = render partial: "items/shared/top_footer"

--- a/db/migrate/20200423123034_change_column_to_seller_null.rb
+++ b/db/migrate/20200423123034_change_column_to_seller_null.rb
@@ -1,0 +1,5 @@
+class ChangeColumnToSellerNull < ActiveRecord::Migration[5.0]
+  def up
+    change_column_null :items, :seller_id, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200418091714) do
+ActiveRecord::Schema.define(version: 20200423123034) do
 
   create_table "addresses", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer  "postal_code",     null: false
@@ -74,7 +74,7 @@ ActiveRecord::Schema.define(version: 20200418091714) do
     t.integer  "product_condition",                             null: false
     t.integer  "shipping_charge",                               null: false
     t.integer  "days_of_ship",                                  null: false
-    t.integer  "seller_id"
+    t.integer  "seller_id",                                     null: false
     t.integer  "buyer_id"
     t.string   "brand"
     t.string   "size"


### PR DESCRIPTION
# WHAT
商品詳細表示の実装修正
# WHY
表示の修正をしてカテゴリーを表示させるため。

カテゴリーの表示や、その他ページ内のリンク表示を修正しました。
売り切れの際、商品詳細ページの購入ボタンを「売り切れました」の仕様にしました。
https://i.gyazo.com/78762e1e5229ec499e774fd625276e14.png